### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can also use `setup.py` to install `planetMagFields`:
 
 $ git clone https://github.com/AnkitBarik/planetMagFields
 $ cd planetMagFields
-$ pytho3 setup.py install --user
+$ python3 setup.py install --user
 ```
 
 Or using `pip`:


### PR DESCRIPTION
Corrected a typo in the setup instructions where python3 was misspelled as “pytho3” (sorry if this is too much for a pr)